### PR TITLE
Add feed generator plugin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,7 @@ title: Nadri's musings
 
 plugins:
   - jekyll-remote-theme
+  - jekyll-feed
 
 # Use upstream minima instead of GitHub Page's outdated version.
 remote_theme: jekyll/minima


### PR DESCRIPTION
This adds the theme's required plugin to generate the Atom/RSS feed.

You can check `minimal`'s [_config.yml](https://github.com/jekyll/minima/blob/master/_config.yml) to check the other suggested options.