### PR TITLE
Fix broken RSS feed

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Build with Jekyll
-        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        run: bundle exec jekyll build
         env:
           JEKYLL_ENV: production
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,8 @@
 author: Nadri
 title: Nadri's musings
 repository: Nadrieril/blog
+url: https://nadrieril.github.io
+baseurl: /blog
 
 markdown: GFM
 


### PR DESCRIPTION
The [current live RSS feed](https://nadrieril.github.io/blog/feed.xml) is broken: the domain is `github.com` instead of `nadrieril.github.io`.

This PR adds to the `url` field to `_config.yml` to fix the problem.